### PR TITLE
Add Cobra CLI flags for configuration and server address

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module earapi
 
-go 1.21.5
-toolchain go1.24.1
+go 1.23.0
+
+toolchain go1.24.3
 
 //replace github.com/earentir/netflixtudumscrapper => ../netflixtudumscrapper
 
@@ -14,6 +15,7 @@ require (
 	github.com/earentir/steamapidata v1.0.3
 	github.com/earentir/tmdbapidata v1.0.0
 	github.com/gin-gonic/gin v1.9.1
+	github.com/spf13/cobra v1.9.1
 )
 
 require (
@@ -29,6 +31,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.17.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.6 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
@@ -36,6 +39,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.1 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d/go.mod h1:8EPpV
 github.com/chenzhuoyu/iasm v0.9.0/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
 github.com/chenzhuoyu/iasm v0.9.1 h1:tUHQJXo3NhBqw6s33wkGn9SP3bvrWLdlVIJ3hQBL7P0=
 github.com/chenzhuoyu/iasm v0.9.1/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyruzin/golang-tmdb v1.5.7 h1:5qENXt1Y8aqO/UHvgI8qepqDQWmNvLdKgKh10+oEwag=
 github.com/cyruzin/golang-tmdb v1.5.7/go.mod h1:ZSryJLCcY+9TiKU+LbouXKns++YBrM8Tizannr05c+I=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -44,6 +45,8 @@ github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MG
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
@@ -63,6 +66,11 @@ github.com/pelletier/go-toml/v2 v2.1.1 h1:LWAJwfNvjQZCFIDKWYQaM62NcYeYViCmWIwmOS
 github.com/pelletier/go-toml/v2 v2.1.1/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/main.go
+++ b/main.go
@@ -11,77 +11,99 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/spf13/cobra"
 )
 
 var (
 	apiversion = "v0.0.26"
-	configFile = "config/earapi.json"
+	configFile string
+	ip         string
+	port       string
 	config     earapiSettings
 )
 
-func main() {
+var rootCmd = &cobra.Command{
+	Use:   "earapi",
+	Short: "Start the earapi server",
+	Run: func(cmd *cobra.Command, args []string) {
+		loadConfig()
 
-	loadConfig()
+		if cmd.Flags().Changed("ip") {
+			config.API.IP = ip
+		} else if config.API.IP == "" {
+			config.API.IP = ip
+		}
 
-	//setup gin to build the API
-	r := gin.Default()
+		if cmd.Flags().Changed("port") {
+			config.API.Port = port
+		} else if config.API.Port == "" {
+			config.API.Port = port
+		}
 
-	// Handler for the root path
-	r.GET("/", func(c *gin.Context) { rootHandler(c, r) })
+		r := gin.Default()
 
-	steamv1Group := r.Group("/steam/v1/")
-	{
-		// steamGroup.GET("/", steamHandler)
-		steamv1Group.GET("/top", steamTopHandler)
-		steamv1Group.GET("/getuserid", steamUserIDHandler)
-		steamv1Group.GET("/appsused", steamUserAppsUsedHandler)
-		steamv1Group.GET("/appdata", steamAppDataHandler)
-		steamv1Group.GET("/search", searchSteamAppHandler)
-	}
+		// Handler for the root path
+		r.GET("/", func(c *gin.Context) { rootHandler(c, r) })
 
-	r.GET("/joke", jokeHandler)
+		steamv1Group := r.Group("/steam/v1/")
+		{
+			steamv1Group.GET("/top", steamTopHandler)
+			steamv1Group.GET("/getuserid", steamUserIDHandler)
+			steamv1Group.GET("/appsused", steamUserAppsUsedHandler)
+			steamv1Group.GET("/appdata", steamAppDataHandler)
+			steamv1Group.GET("/search", searchSteamAppHandler)
+		}
 
-	tmdbGroup := r.Group("/tmdb/v1/")
-	{
-		// movieGroup.GET("/", movieHandler)
-		tmdbGroup.GET("/search", movieSearchHandler)
-		// movieGroup.GET("/actor", movieActorHandler)
-	}
+		r.GET("/joke", jokeHandler)
 
-	netflixGroup := r.Group("/netflix/v1/")
-	{
-		netflixGroup.GET("/top", netflixTopHandler)
-	}
+		tmdbGroup := r.Group("/tmdb/v1/")
+		{
+			tmdbGroup.GET("/search", movieSearchHandler)
+		}
 
-	r.GET("/version", versionHandler)
+		netflixGroup := r.Group("/netflix/v1/")
+		{
+			netflixGroup.GET("/top", netflixTopHandler)
+		}
 
-	// r.Run(fmt.Sprintf("%s%s", ":", config.API.Port))
+		r.GET("/version", versionHandler)
 
-	httpserver :=
-		&http.Server{
-			Addr:    fmt.Sprintf("%s%s", ":", config.API.Port),
+		httpserver := &http.Server{
+			Addr:    fmt.Sprintf("%s:%s", config.API.IP, config.API.Port),
 			Handler: r,
 		}
 
-	go func() {
-		if err := httpserver.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		go func() {
+			if err := httpserver.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				fmt.Println(err)
+			}
+		}()
+
+		signals := make(chan os.Signal)
+		signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
+		<-signals
+		fmt.Println("Shutting down the API")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := httpserver.Shutdown(ctx); err != nil {
 			fmt.Println(err)
 		}
+	},
+}
 
-	}()
+func init() {
+	rootCmd.Flags().StringVar(&configFile, "config", "config/earapi.json", "Path to config file")
+	rootCmd.Flags().StringVar(&ip, "ip", "127.0.0.1", "IP address to listen on")
+	rootCmd.Flags().StringVar(&port, "port", "8080", "Port to listen on")
+}
 
-	//setup channels for capturing the termination signal from the OS
-	signals := make(chan os.Signal)
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
-
-	<-signals
-	fmt.Println("Shutting down the API")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	if err := httpserver.Shutdown(ctx); err != nil {
+func main() {
+	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
+		os.Exit(1)
 	}
 }
 

--- a/structs.go
+++ b/structs.go
@@ -8,6 +8,7 @@ type steamTopResponse struct {
 
 type earapiSettings struct {
 	API struct {
+		IP   string `json:"ip"`
 		Port string `json:"port"`
 	} `json:"api"`
 	Apikeys struct {

--- a/utils.go
+++ b/utils.go
@@ -19,14 +19,15 @@ func loadConfig() {
 	if os.IsNotExist(err) {
 		fmt.Println("Config file not found, creating default config file")
 		err = os.WriteFile(configFile, []byte(`{
-			"api": {
-				"port": "8080"
-			},
-			"apikeys": {
-				"steamapikey": "",
-				"tmdbapitoken": ""
-			}
-		}`), 0644)
+                       "api": {
+                               "ip": "127.0.0.1",
+                               "port": "8080"
+                       },
+                       "apikeys": {
+                               "steamapikey": "",
+                               "tmdbapitoken": ""
+                       }
+               }`), 0644)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(125)


### PR DESCRIPTION
## Summary
- add Cobra-based CLI to parse `--config`, `--ip`, and `--port` flags
- expand configuration schema and default file to include ip and port
- use parsed values when starting HTTP server

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a5b32a06fc832da2c87b90c4fe8cdd